### PR TITLE
Fix to resolve Create service failure when configuration JSON is passed

### DIFF
--- a/lib/create-service.js
+++ b/lib/create-service.js
@@ -53,7 +53,7 @@ function configureParams(details, callback) {
   var params =['create-service', details.type, details.plan, details.name]
   if ('config' in details) {
     params.push('-c')
-    params.push(JSON.toString(details.config))
+    params.push(JSON.stringify(details.config))
   }
   return params
 }


### PR DESCRIPTION
* The change includes fix to create service successfully when configuration object is passed.

https://docs.cloudfoundry.org/devguide/services/managing-services.html#create